### PR TITLE
Update Cargo.toml for target specific dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ description = "Get a unique thread ID"
 repository = "https://github.com/ruuda/thread-id"
 documentation = "https://ruuda.github.io/thread-id/doc/v2.0.0/thread-id/"
 
-[dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2.6"
+
+[target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2.1"


### PR DESCRIPTION
Cargo will unnecessarily download and compile windows specific crates (kernel32-sys and its dependencies) on a unix system if target specific dependencies are not specified.
